### PR TITLE
Return the object if no keys are supplied

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ Object.defineProperty(Object.prototype, 'dig', {
     let digest = Object(this);
     let d = null;
 
+    if(Array.isArray(keys) && keys.length === 0) return digest;
+
     if (keys[keys.length - 1].hasOwnProperty('default')) {
       d = keys[keys.length - 1].default;
       keys.splice(-1, 1);

--- a/test/index.js
+++ b/test/index.js
@@ -78,6 +78,16 @@ describe('Dig', () => {
     assert(testObject.dig() === testObject);
   });
 
+  it('will return the object if passed in as default value when keys are not supplied', () => {
+    const testObject = {
+      other: {
+        name: 'Christoph'
+      }
+    };
+
+    assert(testObject.dig(...[], {default: testObject}) === testObject);
+  });
+
   it('will return an empty array if passed in as default value', () => {
     const testObject = {
       other: {

--- a/test/index.js
+++ b/test/index.js
@@ -68,6 +68,16 @@ describe('Dig', () => {
     assert(testObject.dig('other', 'more', 0, 'wrong', 'first', 'value') === null);
   })
 
+  it('will return the object if keys are not supplied', () => {
+    const testObject = {
+      other: {
+        name: 'Christoph'
+      }
+    };
+
+    assert(testObject.dig() === testObject);
+  });
+
   it('will return an empty array if passed in as default value', () => {
     const testObject = {
       other: {


### PR DESCRIPTION
Hi @devchris,

As I was building a library that was in dire need of the dig method, I needed a way to return the original object if I didn't supply any keys. This PR allows a user to return the object itself if it doesn't want to dig into the object. 

Later I figured that I can use the default setting to return the original object 😅. What do you think?

```javascript
testObject = { 
  other: {
    name: 'Chris'
  }
}

// Input is a string, split by dots (which makes an array)
const input = 'other.name'
testObject.dig(...input.split('.')) // => 'Chris'

emptyArray = [];
testObject.dig(...emptyArray) // => <testObject>
testObject.dig(...emptyArray, { default: testObject }) // => <testObject>
```